### PR TITLE
clear table when context is empty

### DIFF
--- a/UI/web-src/ngMango/components/scriptContext/scriptContext.js
+++ b/UI/web-src/ngMango/components/scriptContext/scriptContext.js
@@ -26,9 +26,9 @@ class scriptContextController {
     render() {
         this.contextPoints = this.ngModelCtrl.$viewValue;
         
-        if (!this.contextPoints) {
-            this.contextPoints = [];
-        } else if (this.contextPoints.length > 0) {
+        if (Array.isArray(this.contextPoints) && this.contextPoints.length === 0) {
+            this.contextTable = angular.copy(this.contextPoints);
+        } else if (Array.isArray(this.contextPoints) && this.contextPoints.length > 0) {
             this.getPoints();
         }
     }


### PR DESCRIPTION
ContextTable was not clearing.  If you clicked on a scripting data source that had no context saved.  You would see the context of a previous DS.  Only when going from one scripting DS to another scripting DS.