### PR TITLE
Scripting editor fixes

### DIFF
--- a/UI/web-src/ngMango/components/scriptingEditor/scriptingEditor.html
+++ b/UI/web-src/ngMango/components/scriptingEditor/scriptingEditor.html
@@ -32,10 +32,10 @@
     <div flex="100" flex-gt-sm="50" ng-if="!$ctrl.scriptOutput && !$ctrl.scriptErrors && !$ctrl.scriptActions"></div>
     
     <div layout="row" layout-gt-sm="column">
-        <md-button class="md-raised md-primary" ng-disabled="$ctrl.disabled" ng-click="$ctrl.validate($event)">
+        <md-button class="md-raised md-primary" ng-disabled="$ctrl.disableValidation" ng-click="$ctrl.validate($event)">
             <md-icon>done</md-icon> <span ma-tr="scriptingEditor.ui.validate"></span>
         </md-button>
-        <md-button class="md-raised" ng-disabled="$ctrl.disabled" ng-click="$ctrl.hideOutput()" ng-if="$ctrl.scriptOutput || $ctrl.scriptErrors || $ctrl.scriptActions">
+        <md-button class="md-raised" ng-click="$ctrl.hideOutput()" ng-if="$ctrl.scriptOutput || $ctrl.scriptErrors || $ctrl.scriptActions">
             <md-icon>close</md-icon> <span ma-tr="common.close"></span>
         </md-button>
     </div>

--- a/UI/web-src/ngMango/components/scriptingEditor/scriptingEditor.html
+++ b/UI/web-src/ngMango/components/scriptingEditor/scriptingEditor.html
@@ -20,6 +20,9 @@
                 <span ng-if="error.columnNumber == null" ma-tr="ui.components.errorOnLine" ma-tr-args="[error.message, error.lineNumber]"></span>
                 <span ng-if="error.columnNumber != null" ma-tr="ui.components.errorOnLineCol" ma-tr-args="[error.message, error.lineNumber, error.columnNumber]"></span>
             </li>
+            <li ng-repeat="error in $ctrl.scriptErrors" ng-if="!error.property && (error.lineNumber == null || error.columnNumber == null)">
+                <span ng-bind="error.message"></span>
+            </li>
         </ul>
         <ul ng-if="$ctrl.scriptActions" class="md-padding ma-script-actions">
             <li ng-repeat="action in $ctrl.scriptActions">

--- a/UI/web-src/ngMango/components/scriptingEditor/scriptingEditor.js
+++ b/UI/web-src/ngMango/components/scriptingEditor/scriptingEditor.js
@@ -171,6 +171,7 @@ class scriptingEditorController {
 
 export default {
     bindings: {
+        disableValidation: '<?',
         context: '<',
         resultDataType: '<?',
         wrapInFunction: '<?',


### PR DESCRIPTION
- added a `disable-validation` property, which disables the `validation` button.
- when `lineNumber`or `columnNumber` are `null`, and `property` is `null` just show the error message