### PR TITLE
check that both lineNumber and columnNumber are null to show the message

### DIFF
--- a/UI/web-src/ngMango/components/scriptingEditor/scriptingEditor.html
+++ b/UI/web-src/ngMango/components/scriptingEditor/scriptingEditor.html
@@ -20,7 +20,7 @@
                 <span ng-if="error.columnNumber == null" ma-tr="ui.components.errorOnLine" ma-tr-args="[error.message, error.lineNumber]"></span>
                 <span ng-if="error.columnNumber != null" ma-tr="ui.components.errorOnLineCol" ma-tr-args="[error.message, error.lineNumber, error.columnNumber]"></span>
             </li>
-            <li ng-repeat="error in $ctrl.scriptErrors" ng-if="!error.property && (error.lineNumber == null || error.columnNumber == null)">
+            <li ng-repeat="error in $ctrl.scriptErrors" ng-if="!error.property && error.lineNumber == null && error.columnNumber == null">
                 <span ng-bind="error.message"></span>
             </li>
         </ul>


### PR DESCRIPTION
I've just found a bug that shows a duplicate error message when the lineNumber is not null, but the column number is null. Now, the message is showed only when both lineNumber and columnNumber are null