### PR TITLE
Potencial fix for infiniteautomation/ma-modules-public#77

### DIFF
--- a/UI/web-src/ngMango/services/dialogHelper.js
+++ b/UI/web-src/ngMango/services/dialogHelper.js
@@ -244,8 +244,14 @@ function DialogHelperFactory($injector, maTranslate, maSystemActions, $q, maUtil
             }).then(finishedResult => {
                 const results = finishedResult.results;
                 if (results.failed) {
-                    const msg = results.exception ? results.exception.message : '';
-                    this.toastOptions({textTr: ['ui.app.systemAction.failed', description, msg], hideDelay: 10000, classes: 'md-warn'});
+                    let msg = results.exception ? results.exception.message : '';
+                    if (results.messages.length > 0) {
+                        results.messages.forEach(message => {
+                            this.toastOptions({textTr: ['ui.app.systemAction.failed', description, message.genericMessage], hideDelay: 10000, classes: 'md-warn'});
+                        })
+                    } else {
+                        this.toastOptions({textTr: ['ui.app.systemAction.failed', description, msg], hideDelay: 10000, classes: 'md-warn'});
+                    }
                 } else {
                     this.toastOptions({textTr: ['ui.app.systemAction.succeeded', description, [options.resultsTr, results]]});
                 }


### PR DESCRIPTION
Since the systems settings is using a global component to display success and errors adding the error right under the input would be difficult as the response returns in the dialogHelper component, Hence my fix was adding the specialized error message in the toast component

![image](https://user-images.githubusercontent.com/46226655/75614485-27de4c00-5b07-11ea-9997-0f515c0a3cf9.png)
