### PR TITLE
fix filestores bug, so it can redirects to the correct path from the url

### DIFF
--- a/UI/web-src/ngMango/components/fileStoreBrowser/fileStoreBrowser.js
+++ b/UI/web-src/ngMango/components/fileStoreBrowser/fileStoreBrowser.js
@@ -119,7 +119,7 @@ class FileStoreBrowserController {
             const fileStore = this.$stateParams.fileStore;
             const folderPath = this.$stateParams.folderPath ? this.$stateParams.folderPath.split('/') : [];
 
-            if (fileStore === defaultStore) {
+            if (fileStore !== defaultStore) {
                 folderPath.unshift(fileStore);
                 this.path = folderPath;
             }


### PR DESCRIPTION
The file stores always redirects to the “default” store, even when you have a different path in the url. I think this should fix the problem.
